### PR TITLE
feat: add polygon, polygon-gradient, and custom GIF animations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The `useModeAnimation` hook is the main export that provides:
 
 - Theme state management (localStorage persistence)
 - View Transition API integration for smooth animations
-- Two animation types: `CIRCLE` and `BLUR_CIRCLE`
+- Six animation types: `CIRCLE`, `BLUR_CIRCLE`, `QR_SCAN`, `POLYGON`, `POLYGON_GRADIENT`, and `GIF`
 - High-resolution display optimizations (>= 3000px width/height)
 - Accessibility support (respects `prefers-reduced-motion`)
 
@@ -42,6 +42,10 @@ The `useModeAnimation` hook is the main export that provides:
 - Uses the View Transition API (`document.startViewTransition`)
 - Circle animation: CSS `clip-path` with expanding circle
 - Blur circle animation: SVG mask with Gaussian blur filter
+- QR scan animation: CSS `clip-path` polygon sweeping left to right
+- Polygon animation: CSS `clip-path` diagonal wipe (direction depends on target theme)
+- Polygon gradient animation: SVG mask with gradient triangle scaling from the top-left corner
+- GIF animation: custom GIF used as a CSS mask that scales up to reveal the new theme (requires `gifUrl` prop)
 - Dynamic calculations for optimal circle positioning and sizing
 - Performance optimizations for high-resolution displays
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@
   <img src="https://github.com/user-attachments/assets/b09898f4-c0ed-48dd-817c-c9f89bfecf2e">
 </p>
 
-### ✨ Three Animation Types Available
+### ✨ Six Animation Types Available
 
 - **🔵 Circle**: Smooth expanding circle transition
 - **🌀 Blur Circle**: Circle with elegant blur effect on the edges
 - **📱 QR Scan**: Scanning line sweeps left to right (like QR code reader)
+- **🔷 Polygon**: Diagonal wipe that sweeps across the screen
+- **📐 Polygon Gradient**: Diagonal wipe with a soft gradient edge
+- **🎬 Custom GIF**: Reveal the new theme through any GIF mask of your choice
 
 ## 📝 Notes
 
@@ -33,7 +36,7 @@
 
 ## 🚀 Features
 
-- **🎨 Multiple Animation Types**: Circle, Blur Circle, and QR Scan animations
+- **🎨 Multiple Animation Types**: Circle, Blur Circle, QR Scan, Polygon, Polygon Gradient, and Custom GIF animations
 - **⚡ High Performance**: Optimized for high-resolution displays with smooth 60fps animations
 - **🎯 View Transition API**: Leverages modern browser APIs for seamless transitions
 - **📱 Responsive Design**: Works perfectly across all device sizes and screen resolutions
@@ -84,25 +87,29 @@ export default MyComponent
 
 `useModeAnimation` accepts an optional `props` object with the following properties:
 
-| Property           | Type                      | Default                         | Description                                                   |
-| ------------------ | ------------------------- | ------------------------------- | ------------------------------------------------------------- |
-| `duration`         | number                    | `750`                           | Duration of the animation in milliseconds.                    |
-| `easing`           | string                    | `"ease-in-out"`                 | CSS easing type for the animation.                            |
-| `pseudoElement`    | string                    | `"::view-transition-new(root)"` | Pseudo-element used for the animation.                        |
-| `globalClassName`  | string                    | `"dark"`                        | Class name to apply to the root element.                      |
-| `animationType`    | ThemeAnimationType        | `ThemeAnimationType.CIRCLE`     | Type of animation effect (`CIRCLE`, `BLUR_CIRCLE`, `QR_SCAN`) |
-| `blurAmount`       | number                    | `2`                             | Blur intensity for blur circle animation.                     |
-| `styleId`          | string                    | `"theme-switch-style"`          | ID for the style element (blur circle animation).             |
-| `isDarkMode`       | boolean                   | `false`                         | Initial dark mode state.                                      |
-| `onDarkModeChange` | (isDark: boolean) => void | `undefined`                     | Callback function to handle dark mode change.                 |
+| Property           | Type                      | Default                         | Description                                                                                                 |
+| ------------------ | ------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `duration`         | number                    | `750`                           | Duration of the animation in milliseconds (defaults to `1500` for `POLYGON_GRADIENT` and `2000` for `GIF`). |
+| `easing`           | string                    | `"ease-in-out"`                 | CSS easing for the animation (defaults to an expo curve for `POLYGON`, `POLYGON_GRADIENT`, and `GIF`).      |
+| `pseudoElement`    | string                    | `"::view-transition-new(root)"` | Pseudo-element used for the animation.                                                                      |
+| `globalClassName`  | string                    | `"dark"`                        | Class name to apply to the root element.                                                                    |
+| `animationType`    | ThemeAnimationType        | `ThemeAnimationType.CIRCLE`     | Type of animation effect (`CIRCLE`, `BLUR_CIRCLE`, `QR_SCAN`, `POLYGON`, `POLYGON_GRADIENT`, `GIF`)         |
+| `blurAmount`       | number                    | `2`                             | Blur intensity for blur circle animation.                                                                   |
+| `gifUrl`           | string                    | `undefined`                     | URL of the GIF used as the reveal mask (required for the `GIF` animation type).                             |
+| `styleId`          | string                    | `"theme-switch-style"`          | ID for the injected style element (blur circle, polygon gradient, and gif animations).                      |
+| `isDarkMode`       | boolean                   | `false`                         | Initial dark mode state.                                                                                    |
+| `onDarkModeChange` | (isDark: boolean) => void | `undefined`                     | Callback function to handle dark mode change.                                                               |
 
 ### Animation Types
 
-The hook supports three types of animations:
+The hook supports six types of animations:
 
 - `ThemeAnimationType.CIRCLE`: A clean circle expansion animation (default)
 - `ThemeAnimationType.BLUR_CIRCLE`: A circle expansion with blur effect on the edges
 - `ThemeAnimationType.QR_SCAN`: A scanning line that sweeps from left to right
+- `ThemeAnimationType.POLYGON`: A diagonal wipe — toward dark it sweeps from the top-left corner, back to light from the bottom-right
+- `ThemeAnimationType.POLYGON_GRADIENT`: A diagonal wipe with a soft gradient edge expanding from the top-left corner
+- `ThemeAnimationType.GIF`: Reveals the new theme through a custom GIF mask that scales up to fill the screen (requires `gifUrl`)
 
 ### Examples for Each Animation Type
 
@@ -172,6 +179,74 @@ const QRScanAnimation = () => {
 }
 ```
 
+#### Polygon Animation
+
+```jsx
+'use client'
+
+import React from 'react'
+import { ThemeAnimationType, useModeAnimation } from 'react-theme-switch-animation'
+
+const PolygonAnimation = () => {
+  const { ref, toggleSwitchTheme, isDarkMode } = useModeAnimation({
+    animationType: ThemeAnimationType.POLYGON,
+  })
+
+  return (
+    <button ref={ref} onClick={toggleSwitchTheme}>
+      {isDarkMode ? '🌙' : '☀️'} Toggle Theme (Polygon)
+    </button>
+  )
+}
+```
+
+#### Polygon Gradient Animation
+
+```jsx
+'use client'
+
+import React from 'react'
+import { ThemeAnimationType, useModeAnimation } from 'react-theme-switch-animation'
+
+const PolygonGradientAnimation = () => {
+  const { ref, toggleSwitchTheme, isDarkMode } = useModeAnimation({
+    animationType: ThemeAnimationType.POLYGON_GRADIENT,
+    duration: 1500, // Optional: defaults to 1500ms for this animation
+  })
+
+  return (
+    <button ref={ref} onClick={toggleSwitchTheme}>
+      {isDarkMode ? '🌙' : '☀️'} Toggle Theme (Polygon Gradient)
+    </button>
+  )
+}
+```
+
+#### Custom GIF Animation
+
+```jsx
+'use client'
+
+import React from 'react'
+import { ThemeAnimationType, useModeAnimation } from 'react-theme-switch-animation'
+
+const GifAnimation = () => {
+  const { ref, toggleSwitchTheme, isDarkMode } = useModeAnimation({
+    animationType: ThemeAnimationType.GIF,
+    gifUrl: 'https://media.tenor.com/cyORI7kwShQAAAAi/shigure-ui-dance.gif', // Any GIF URL
+    duration: 2000, // Optional: defaults to 2000ms for this animation
+  })
+
+  return (
+    <button ref={ref} onClick={toggleSwitchTheme}>
+      {isDarkMode ? '🌙' : '☀️'} Toggle Theme (GIF)
+    </button>
+  )
+}
+```
+
+> **Tip:** GIFs with transparent backgrounds work best as masks — the theme is revealed through the opaque parts of the GIF. If `gifUrl` is omitted, the hook falls back to the circle animation.
+
 Returns an object containing:
 
 - `ref`: React ref for attaching to the component that will trigger the dark mode toggle.
@@ -199,6 +274,10 @@ This library is built with performance in mind:
 - React 16.8 or later (for Hooks support)
 - TypeScript for compiling the package during installation
 - TailwindCSS for styling (ensure dark mode is configured)
+
+## 🙏 Acknowledgements
+
+The polygon, polygon gradient, and GIF animations are inspired by [rudrodip/theme-toggle-effect](https://github.com/rudrodip/theme-toggle-effect).
 
 ## 🤝 Contributing
 

--- a/example/src/app/page.tsx
+++ b/example/src/app/page.tsx
@@ -13,7 +13,17 @@ export default function Home() {
     setIsDarkMode(isDark)
   }
 
-  const animations = [
+  const animations: Array<{
+    type: ThemeAnimationType
+    title: string
+    description: string
+    icon: string
+    gradient: string
+    bgPattern: string
+    duration: string
+    easing: string
+    gifUrl?: string
+  }> = [
     {
       type: ThemeAnimationType.CIRCLE,
       title: 'Circle',
@@ -21,6 +31,8 @@ export default function Home() {
       icon: '⭕',
       gradient: 'from-blue-500 to-purple-600',
       bgPattern: 'bg-gradient-to-br',
+      duration: '750ms',
+      easing: 'ease-in-out',
     },
     {
       type: ThemeAnimationType.BLUR_CIRCLE,
@@ -29,6 +41,8 @@ export default function Home() {
       icon: '🌀',
       gradient: 'from-emerald-500 to-teal-600',
       bgPattern: 'bg-gradient-to-br',
+      duration: '750ms',
+      easing: 'ease-in-out',
     },
     {
       type: ThemeAnimationType.QR_SCAN,
@@ -37,6 +51,39 @@ export default function Home() {
       icon: '📱',
       gradient: 'from-orange-500 to-red-600',
       bgPattern: 'bg-gradient-to-br',
+      duration: '750ms',
+      easing: 'ease-in-out',
+    },
+    {
+      type: ThemeAnimationType.POLYGON,
+      title: 'Polygon',
+      description: 'Diagonal wipe sweeping across the screen',
+      icon: '🔷',
+      gradient: 'from-violet-500 to-fuchsia-600',
+      bgPattern: 'bg-gradient-to-br',
+      duration: '750ms',
+      easing: 'expo-out',
+    },
+    {
+      type: ThemeAnimationType.POLYGON_GRADIENT,
+      title: 'Polygon Gradient',
+      description: 'Diagonal wipe with a soft gradient edge',
+      icon: '📐',
+      gradient: 'from-cyan-500 to-blue-600',
+      bgPattern: 'bg-gradient-to-br',
+      duration: '1500ms',
+      easing: 'expo-out',
+    },
+    {
+      type: ThemeAnimationType.GIF,
+      title: 'Custom GIF',
+      description: 'Reveal the theme through any GIF mask',
+      icon: '🎬',
+      gradient: 'from-pink-500 to-rose-600',
+      bgPattern: 'bg-gradient-to-br',
+      duration: '2000ms',
+      easing: 'expo-in',
+      gifUrl: 'https://media.tenor.com/cyORI7kwShQAAAAi/shigure-ui-dance.gif',
     },
   ]
 
@@ -123,6 +170,7 @@ export default function Home() {
                     <div className="absolute inset-0 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full blur-xl opacity-20 group-hover:opacity-40 transition-opacity duration-300"></div>
                     <SwitchDarkMode
                       animationType={animation.type}
+                      gifUrl={animation.gifUrl}
                       styleId={`${animation.type}-showcase`}
                       isDarkMode={isDarkMode}
                       onDarkModeChange={handleDarkModeChange}
@@ -134,11 +182,11 @@ export default function Home() {
                 <div className="mt-6 pt-6 border-t border-slate-200 dark:border-slate-700">
                   <div className="flex items-center justify-between text-sm">
                     <span className="text-slate-500 dark:text-slate-400">Duration</span>
-                    <span className="font-mono text-slate-700 dark:text-slate-300">750ms</span>
+                    <span className="font-mono text-slate-700 dark:text-slate-300">{animation.duration}</span>
                   </div>
                   <div className="flex items-center justify-between text-sm mt-2">
                     <span className="text-slate-500 dark:text-slate-400">Easing</span>
-                    <span className="font-mono text-slate-700 dark:text-slate-300">ease-in-out</span>
+                    <span className="font-mono text-slate-700 dark:text-slate-300">{animation.easing}</span>
                   </div>
                 </div>
               </div>
@@ -166,7 +214,7 @@ export default function Home() {
               {
                 icon: '🎨',
                 title: 'Multiple Animations',
-                description: 'Circle, blur circle, and QR scan effects with more coming soon',
+                description: 'Circle, blur circle, QR scan, polygon, polygon gradient, and custom GIF effects',
               },
               {
                 icon: '📱',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-theme-switch-animation",
   "version": "1.0.0",
-  "description": "Beautiful, smooth animations for theme switching in React applications. Features Circle, Blur Circle, and QR Scan animations with TypeScript support.",
+  "description": "Beautiful, smooth animations for theme switching in React applications. Features Circle, Blur Circle, QR Scan, Polygon, Polygon Gradient, and Custom GIF animations with TypeScript support.",
   "keywords": [
     "react",
     "reactjs",
@@ -17,6 +17,9 @@
     "circle",
     "blur",
     "qr-scan",
+    "polygon",
+    "polygon-gradient",
+    "gif",
     "theme-toggle",
     "dark-mode",
     "tailwindcss",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,30 @@ export enum ThemeAnimationType {
   CIRCLE = 'circle',
   BLUR_CIRCLE = 'blur-circle',
   QR_SCAN = 'qr-scan',
+  POLYGON = 'polygon',
+  POLYGON_GRADIENT = 'polygon-gradient',
+  GIF = 'gif',
 }
+
+// Exponential easing curves (CSS linear() approximations) used by the
+// polygon and gif animations for a snappy reveal effect
+const EXPO_OUT_EASING =
+  'linear(' +
+  '0 0%, 0.1684 2.66%, 0.3165 5.49%, 0.446 8.52%,' +
+  '0.5581 11.78%, 0.6535 15.29%, 0.7341 19.11%,' +
+  '0.8011 23.3%, 0.8557 27.93%, 0.8962 32.68%,' +
+  '0.9283 38.01%, 0.9529 44.08%, 0.9711 51.14%,' +
+  '0.9833 59.06%, 0.9915 68.74%, 1 100%' +
+  ')'
+
+const EXPO_IN_EASING =
+  'linear(' +
+  '0 0%, 0.0085 31.26%, 0.0167 40.94%, 0.0289 48.86%,' +
+  '0.0471 55.92%, 0.0717 61.99%, 0.1038 67.32%,' +
+  '0.1443 72.07%, 0.1989 76.7%, 0.2659 80.89%,' +
+  '0.3465 84.71%, 0.4419 88.22%, 0.554 91.48%,' +
+  '0.6835 94.51%, 0.8316 97.34%, 1 100%' +
+  ')'
 
 interface ReactThemeSwitchAnimationHook {
   ref: React.RefObject<HTMLButtonElement>
@@ -59,6 +82,7 @@ export interface ReactThemeSwitchAnimationProps {
   globalClassName?: string
   animationType?: ThemeAnimationType
   blurAmount?: number
+  gifUrl?: string
   styleId?: string
   isDarkMode?: boolean
   onDarkModeChange?: (isDark: boolean) => void
@@ -66,16 +90,34 @@ export interface ReactThemeSwitchAnimationProps {
 
 export const useModeAnimation = (props?: ReactThemeSwitchAnimationProps): ReactThemeSwitchAnimationHook => {
   const {
-    duration: propsDuration = 750,
-    easing = 'ease-in-out',
+    duration: customDuration,
+    easing: customEasing,
     pseudoElement = '::view-transition-new(root)',
     globalClassName = 'dark',
     animationType = ThemeAnimationType.CIRCLE,
     blurAmount = 2,
+    gifUrl,
     styleId = 'theme-switch-style',
     isDarkMode: externalDarkMode,
     onDarkModeChange,
   } = props || {}
+
+  // Gif and polygon-gradient animations need more time to read the reveal effect
+  const propsDuration =
+    customDuration ??
+    (animationType === ThemeAnimationType.GIF
+      ? 2000
+      : animationType === ThemeAnimationType.POLYGON_GRADIENT
+        ? 1500
+        : 750)
+
+  const easing =
+    customEasing ??
+    (animationType === ThemeAnimationType.POLYGON || animationType === ThemeAnimationType.POLYGON_GRADIENT
+      ? EXPO_OUT_EASING
+      : animationType === ThemeAnimationType.GIF
+        ? EXPO_IN_EASING
+        : 'ease-in-out')
 
   const isHighResolution = typeof window !== 'undefined' && (window.innerWidth >= 3000 || window.innerHeight >= 2000)
 
@@ -111,6 +153,19 @@ export const useModeAnimation = (props?: ReactThemeSwitchAnimationProps): ReactT
     const circleRadius = isHighResolution ? 20 : 25
 
     return `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 100 100"><defs>${blurFilter}</defs><circle cx="0" cy="0" r="${circleRadius}" fill="white" filter="url(%23blur)"/></svg>')`
+  }
+
+  // Triangle with a soft gradient edge, anchored to the top-left corner
+  const createPolygonGradientMask = () => {
+    const gradient =
+      '<linearGradient id="g" x1="0" y1="0" x2="20.5" y2="20.5" gradientUnits="userSpaceOnUse">' +
+      '<stop stop-color="white"/>' +
+      '<stop offset="0.84506" stop-color="white" stop-opacity="0.99"/>' +
+      '<stop offset="0.9506" stop-color="white" stop-opacity="0"/>' +
+      '<stop offset="1" stop-color="white" stop-opacity="0"/>' +
+      '</linearGradient>'
+
+    return `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><defs>${gradient}</defs><path d="M0 0H40L0 40V0Z" fill="url(%23g)"/></svg>')`
   }
 
   const toggleSwitchTheme = async () => {
@@ -209,23 +264,129 @@ export const useModeAnimation = (props?: ReactThemeSwitchAnimationProps): ReactT
       document.head.appendChild(styleElement)
     }
 
+    if (animationType === ThemeAnimationType.POLYGON_GRADIENT) {
+      const styleElement = document.createElement('style')
+      styleElement.id = styleId
+
+      // Double animation declarations: the second (linear() easing) wins in
+      // browsers that support it, the first is a fallback for those that don't
+      styleElement.textContent = `
+        ::view-transition-group(root) {
+          animation-duration: ${duration}ms;
+          animation-timing-function: ease;
+          animation-timing-function: ${easing};
+        }
+
+        ::view-transition-new(root) {
+          mask: ${createPolygonGradientMask()} top left / 0 no-repeat;
+          animation: polygonGradientScale ${duration}ms ease;
+          animation: polygonGradientScale ${duration}ms ${easing};
+          animation-fill-mode: both;
+          will-change: mask-size;
+        }
+
+        ::view-transition-old(root),
+        .${globalClassName}::view-transition-old(root) {
+          animation: polygonGradientScale ${duration}ms ease;
+          animation: polygonGradientScale ${duration}ms ${easing};
+          animation-fill-mode: both;
+          z-index: -1;
+          transform-origin: top left;
+        }
+
+        @keyframes polygonGradientScale {
+          to {
+            mask-size: 200vmax;
+          }
+        }
+      `
+      document.head.appendChild(styleElement)
+    }
+
+    if (animationType === ThemeAnimationType.GIF && gifUrl) {
+      const styleElement = document.createElement('style')
+      styleElement.id = styleId
+
+      styleElement.textContent = `
+        ::view-transition-group(root) {
+          animation-duration: ${duration}ms;
+          animation-timing-function: ease;
+          animation-timing-function: ${easing};
+        }
+
+        ::view-transition-new(root) {
+          mask: url('${gifUrl}') center / 0 no-repeat;
+          animation: gifMaskScale ${duration}ms ease;
+          animation: gifMaskScale ${duration}ms ${easing};
+          animation-fill-mode: both;
+          will-change: mask-size;
+        }
+
+        ::view-transition-old(root),
+        .${globalClassName}::view-transition-old(root) {
+          animation: gifMaskScale ${duration}ms ease;
+          animation: gifMaskScale ${duration}ms ${easing};
+          animation-fill-mode: both;
+          z-index: -1;
+        }
+
+        @keyframes gifMaskScale {
+          0% {
+            mask-size: 0;
+          }
+          10% {
+            mask-size: 50vmax;
+          }
+          90% {
+            mask-size: 50vmax;
+          }
+          100% {
+            mask-size: 2000vmax;
+          }
+        }
+      `
+      document.head.appendChild(styleElement)
+    }
+
+    if (animationType === ThemeAnimationType.GIF && !gifUrl) {
+      console.warn(
+        'react-theme-switch-animation: `gifUrl` is required for the GIF animation type. Falling back to the circle animation.'
+      )
+    }
+
     await (document as any).startViewTransition(() => {
       flushSync(() => {
         setIsDarkMode((isDarkMode) => !isDarkMode)
       })
     }).ready
 
-    if (animationType === ThemeAnimationType.CIRCLE) {
+    if (animationType === ThemeAnimationType.CIRCLE || (animationType === ThemeAnimationType.GIF && !gifUrl)) {
       document.documentElement.animate(
         {
           clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${maxRadius}px at ${x}px ${y}px)`],
         },
         {
           duration,
-          easing,
+          easing: animationType === ThemeAnimationType.CIRCLE ? easing : 'ease-in-out',
           pseudoElement,
         }
       )
+    }
+
+    if (animationType === ThemeAnimationType.POLYGON) {
+      // Diagonal wipe: toward dark it sweeps from the top-left corner,
+      // back to light it sweeps from the bottom-right corner
+      const willBeDark = !isDarkMode
+      const clipPath = willBeDark
+        ? ['polygon(50% -71%, -50% 71%, -50% 71%, 50% -71%)', 'polygon(50% -71%, -50% 71%, 50% 171%, 171% 50%)']
+        : ['polygon(171% 50%, 50% 171%, 50% 171%, 171% 50%)', 'polygon(171% 50%, 50% 171%, -50% 71%, 50% -71%)']
+
+      try {
+        document.documentElement.animate({ clipPath }, { duration, easing, pseudoElement })
+      } catch {
+        // linear() easing is not supported everywhere the View Transition API is
+        document.documentElement.animate({ clipPath }, { duration, easing: 'ease-in-out', pseudoElement })
+      }
     }
 
     if (animationType === ThemeAnimationType.QR_SCAN) {
@@ -245,7 +406,11 @@ export const useModeAnimation = (props?: ReactThemeSwitchAnimationProps): ReactT
       )
     }
 
-    if (animationType === ThemeAnimationType.BLUR_CIRCLE) {
+    if (
+      animationType === ThemeAnimationType.BLUR_CIRCLE ||
+      animationType === ThemeAnimationType.POLYGON_GRADIENT ||
+      (animationType === ThemeAnimationType.GIF && gifUrl)
+    ) {
       setTimeout(() => {
         const styleElement = document.getElementById(styleId)
         if (styleElement) {


### PR DESCRIPTION
## Summary

Adds three new theme switch animation types inspired by [rudrodip/theme-toggle-effect](https://github.com/rudrodip/theme-toggle-effect), bringing the library to six animation types total.

### 🔷 `ThemeAnimationType.POLYGON`
A diagonal clip-path wipe across the screen. Toward dark mode it sweeps from the top-left corner; back to light mode it sweeps from the bottom-right. Uses an expo-out `linear()` easing curve by default for a snappy reveal.

### 📐 `ThemeAnimationType.POLYGON_GRADIENT`
A diagonal wipe with a soft gradient edge — a gradient triangle SVG mask anchored at the top-left corner scales up to `200vmax`. Defaults to 1500ms with expo-out easing.

### 🎬 `ThemeAnimationType.GIF`
Reveals the new theme through any GIF of your choice via the new `gifUrl` prop. The GIF mask scales to `50vmax`, holds while the GIF plays, then expands to `2000vmax` to fill the screen. Defaults to 2000ms with expo-in easing. If `gifUrl` is omitted, the hook warns and gracefully falls back to the circle animation.

## Implementation notes

- New optional `gifUrl` prop on `ReactThemeSwitchAnimationProps`
- Per-type duration/easing defaults only apply when the consumer doesn't pass their own values (existing behavior unchanged: 750ms / ease-in-out for circle, blur-circle, and QR scan)
- `linear()` easing strings ship with `ease` fallbacks (duplicate CSS declarations + try/catch around `element.animate`) for browsers that support the View Transition API but not `linear()`
- Injected style elements for the mask-based animations are cleaned up after the animation completes, same as blur-circle
- Old-snapshot selectors respect the `globalClassName` prop instead of hardcoding `.dark`

## Docs & demo

- README: six animation types, `gifUrl` in the API table, per-type default notes, usage examples for each new type, and an acknowledgement of the reference repo
- Example app: three new showcase cards (Polygon, Polygon Gradient, Custom GIF) with accurate per-animation duration/easing labels
- CLAUDE.md architecture notes and package.json description/keywords updated

## Testing

- ✅ Library `tsc` build passes
- ✅ Example app `next build` passes
- ✅ Verified live in Chrome: polygon toggled to dark with `localStorage` persisted, polygon-gradient toggled back to light with its injected style removed afterward, GIF animation confirmed mid-flight (mask URL + keyframes present in injected style) with cleanup and theme switch verified, no console errors